### PR TITLE
chore(package): update gatsby-remark-images to version 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gatsby-plugin-react-helmet": "^1.0.1",
     "gatsby-plugin-sharp": "^1.5.0",
     "gatsby-remark-copy-linked-files": "^1.5.0",
-    "gatsby-remark-images": "^1.5.0",
+    "gatsby-remark-images": "^1.5.4",
     "gatsby-remark-prismjs": "^1.2.0",
     "gatsby-remark-responsive-iframe": "^1.4.1",
     "gatsby-remark-smartypants": "^1.4.1",


### PR DESCRIPTION
Closes #44 