### PR TITLE
chore(package): update gatsby-remark-copy-linked-files to version 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-offline": "^1.0.1",
     "gatsby-plugin-react-helmet": "^1.0.1",
     "gatsby-plugin-sharp": "^1.6.2",
-    "gatsby-remark-copy-linked-files": "^1.5.0",
+    "gatsby-remark-copy-linked-files": "^1.5.2",
     "gatsby-remark-images": "^1.5.4",
     "gatsby-remark-prismjs": "^1.2.1",
     "gatsby-remark-responsive-iframe": "^1.4.3",


### PR DESCRIPTION
Closes #40 