### PR TITLE
chore(package): update gatsby-link to version 1.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@9renpoto/style": "github:9renpoto/style",
     "gatsby": "^1.8.12",
-    "gatsby-link": "^1.6.5",
+    "gatsby-link": "^1.6.8",
     "gatsby-plugin-google-analytics": "^1.0.4",
     "gatsby-plugin-manifest": "^1.0.1",
     "gatsby-plugin-offline": "^1.0.1",


### PR DESCRIPTION
Closes #38 