### PR TITLE
chore(package): update gatsby-remark-prismjs to version 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gatsby-plugin-sharp": "^1.5.0",
     "gatsby-remark-copy-linked-files": "^1.5.0",
     "gatsby-remark-images": "^1.5.4",
-    "gatsby-remark-prismjs": "^1.2.0",
+    "gatsby-remark-prismjs": "^1.2.1",
     "gatsby-remark-responsive-iframe": "^1.4.3",
     "gatsby-remark-smartypants": "^1.4.1",
     "gatsby-source-filesystem": "^1.4.3",


### PR DESCRIPTION
Closes #37 