### PR TITLE
chore(package): update gatsby to version 1.9.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@9renpoto/style": "github:9renpoto/style#build",
-    "gatsby": "^1.9.50",
+    "gatsby": "^1.9.66",
     "gatsby-link": "^1.6.17",
     "gatsby-plugin-feed": "^1.3.9",
     "gatsby-plugin-google-analytics": "^1.0.7",


### PR DESCRIPTION
closes #106 