### PR TITLE
chore(package): update gatsby-remark-images to version 1.5.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gatsby-plugin-sharp": "^1.6.8",
     "gatsby-plugin-sitemap": "^1.2.5",
     "gatsby-remark-copy-linked-files": "^1.5.7",
-    "gatsby-remark-images": "^1.5.13",
+    "gatsby-remark-images": "^1.5.16",
     "gatsby-remark-prismjs": "^1.2.8",
     "gatsby-remark-responsive-iframe": "^1.4.7",
     "gatsby-remark-smartypants": "^1.4.7",


### PR DESCRIPTION
Closes #109 