### PR TITLE
chore(package): update gatsby-remark-copy-linked-files to version 1.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gatsby-plugin-react-helmet": "^1.0.6",
     "gatsby-plugin-sharp": "^1.6.8",
     "gatsby-plugin-sitemap": "^1.2.5",
-    "gatsby-remark-copy-linked-files": "^1.5.8",
+    "gatsby-remark-copy-linked-files": "^1.5.15",
     "gatsby-remark-images": "^1.5.16",
     "gatsby-remark-prismjs": "^1.2.8",
     "gatsby-remark-responsive-iframe": "^1.4.13",


### PR DESCRIPTION
Closes #137 