### PR TITLE
chore(package): update gatsby-remark-prismjs to version 1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gatsby-plugin-sitemap": "^1.2.5",
     "gatsby-remark-copy-linked-files": "^1.5.8",
     "gatsby-remark-images": "^1.5.16",
-    "gatsby-remark-prismjs": "^1.2.8",
+    "gatsby-remark-prismjs": "^1.2.9",
     "gatsby-remark-responsive-iframe": "^1.4.13",
     "gatsby-remark-smartypants": "^1.4.7",
     "gatsby-source-filesystem": "^1.5.5",


### PR DESCRIPTION
Closes #136 